### PR TITLE
Remove unused CovQuestions postinstall action

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "refresh": "sudo docker-compose build frontend && sudo docker-compose up -d frontend",
     "restart": "sudo docker-compose restart frontend",
     "test": "jest --env=jsdom",
-    "coverage": "jest --env=jsdom --coverage",
-    "postinstall": "git clone https://github.com/CovOpen/CovQuestions; cd CovQuestions/covquestions-js; npm install; npm run build; cd ../../node_modules; ln -s ../CovQuestions/covquestions-js/dist covquestions-js"
+    "coverage": "jest --env=jsdom --coverage"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",


### PR DESCRIPTION
## Summary

This removes the `postinstall` action from `package.json`, which attempts to use `npm` to link in the CovQuestions in a crude way.

## Background

Separately `git clone`ing a second repo into the source tree and manually symlinking doesn't work across platforms and makes several overreaching assumptions about the development environment. A better alternative is available with git submodules and/or yarn workspaces once the effort to integrate the two apps is restarted.