### PR TITLE
Emit bundle stats and compare in action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         name: head-stats
     - name: Diff between base & head
-      uses: chronotruck/webpack-stats-diff-action@1.0.0
+      uses: weltenwort/webpack-stats-diff-action@v1.2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         base_stats_path: ./base-stats/bundle-stats.json

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,53 @@
+on:
+  pull_request:
+jobs:
+  build-head:
+    name: 'Build head'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: yarn install
+    - name: Build
+      run: yarn build:prod
+    - name: Upload bundle-stats.json
+      uses: actions/upload-artifact@v1
+      with:
+        name: head-stats
+        path: ./bundle-stats.json
+  build-base:
+    name: 'Build base'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        ref: ${{ github.base_ref }}
+    - name: Install dependencies
+      run: yarn install
+    - name: Build
+      run: yarn build:prod
+    - name: Upload bundle-stats.json
+      uses: actions/upload-artifact@v1
+      with:
+        name: base-stats
+        path: ./bundle-stats.json
+  compare:
+    name: 'Compare base & head bundle sizes'
+    runs-on: ubuntu-latest
+    needs: [build-base, build-head]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Download base artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: base-stats
+    - name: Download head artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: head-stats
+    - name: Diff between base & head
+      uses: chronotruck/webpack-stats-diff-action@1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        base_stats_path: ./base-stats/bundle-stats.json
+        head_stats_path: ./head-stats/bundle-stats.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 bundle-report.html
+bundle-stats.json
 *.generated*
 .now
 .vscode

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -217,8 +217,10 @@ module.exports = function (env) {
     config.plugins.push(
       new BundleAnalyzerPlugin({
         analyzerMode: "static",
+        generateStatsFile: true,
         openAnalyzer: false,
         reportFilename: path.resolve(__dirname, "bundle-report.html"),
+        statsFilename: path.resolve(__dirname, "bundle-stats.json"),
       }),
     );
   } else {


### PR DESCRIPTION
## Summary

This configures webpack to always emit the bundle stats and adds a GitHub action to compare the stats of a PR's head bundle against the PR's base bundle.

:information_source: The base build failure in this PR is expected, because the webpack config in the base branch doesn't produce the required stats file yet.

See weltenwort/CovMapper#1 for an example:

![image](https://user-images.githubusercontent.com/973741/95888324-3e2cd580-0d81-11eb-8045-e78fd7ba286d.png)
