### PR TITLE
Render the risk area layer beneath the feature labels

### DIFF
--- a/apps/official/index.ts
+++ b/apps/official/index.ts
@@ -131,6 +131,7 @@ export const config: AppConfig = {
               ],
               "fill-opacity": 0.5,
             },
+            beforeId: "road-label",
           }),
         },
         {


### PR DESCRIPTION
## Summary

This configures the layer with areas used to indicate the risk colors beneath the feature labels for increased readability.

closes https://trello.com/c/Xz5lnp7T

## Background

By default, `react-map-gl` appends any layers to the end of the layer stack. This means that layers defined in the map style are rendered underneath any additional user-defined layers. In this case the user-defined layers include many filled areas, which causes the feature labels such as city and road names to be occluded by the fill color.

The layer ordering can be influenced by setting the `beforeId` property on the layer definition. This PR therefore sets the `beforeId` of the `areas-fill` layer to `road-labels`, which is the bottom-most label layer in the chosen map style.

:information_source: If a different map style is chosen at some point this might have to be adapted to the layer ids of the new style.

## Previews

**Before:**
![image](https://user-images.githubusercontent.com/973741/96113830-06d73980-0ee5-11eb-9f48-f874542c155b.png)

**After:**
![image](https://user-images.githubusercontent.com/973741/96113849-0ccd1a80-0ee5-11eb-9580-73ffc4ecee0c.png)
