### PR TITLE
Switch bundle size comparison action to pull_request_target

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,11 +1,13 @@
 on:
-  pull_request:
+  pull_request_target:
 jobs:
   build-head:
     name: 'Build head'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      ref: ${{github.event.pull_request.head.ref}}
+      repository: ${{github.event.pull_request.head.repo.full_name}}
     - name: Install dependencies
       run: yarn install
     - name: Build
@@ -19,9 +21,9 @@ jobs:
     name: 'Build base'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-      with:
-        ref: ${{ github.base_ref }}
+    - uses: actions/checkout@v2
+      ref: ${{github.event.pull_request.base.ref}}
+      repository: ${{github.event.pull_request.base.repo.full_name}}
     - name: Install dependencies
       run: yarn install
     - name: Build


### PR DESCRIPTION
## Summary

This switches the action trigger for the bundle size comparison to `pull_request_target` to work around a permission issue that occurs on PRs from forks: https://github.community/t/github-actions-are-severely-limited-on-prs/18179

The trigger type was announced in https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.