### PR TITLE
fix loading error

### DIFF
--- a/src/state/thunks/fetchMappedSet.ts
+++ b/src/state/thunks/fetchMappedSet.ts
@@ -39,7 +39,7 @@ export function fetchMappedSet(visualId: VisualId, mappingId: string, date: Date
     const timeKey = formatUTCDate(date);
     const loadingKey = `loading-${mappingId}-${timeKey}`;
 
-    dispatch(AppApi.pushLoading(loadingKey));
+    dispatch(() => AppApi.pushLoading(loadingKey));
 
     try {
       const mapping = config.visuals[visualId].mappings[mappingId];


### PR DESCRIPTION
Apparently this warning is fairly new. The message says it correlates to `setState`. Here's the comment the message [links to](https://github.com/facebook/react/issues/18178#issuecomment-595846312).

I don't really understand why, but this makes it go away for me.
I suspect passing a callback to dispatch makes it execute some time later, where it can no longer interfere with component rendering?

Any ideas?