### PR TITLE
ci: make teardown more resilient

### DIFF
--- a/.github/workflows/pr-preview-teardown.yml
+++ b/.github/workflows/pr-preview-teardown.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Sleep for 90 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '90s'
       - name: Azure Login
         uses: azure/login@v1
         with:


### PR DESCRIPTION
currently, the teardown process might be executed before another workflow (pr-check) uploads data, thus leaving orphan pull requests previews in the resource group. 

This is the easiest way to achieve that they will be shut down. 