### PR TITLE
chore: fix deploy in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn run semantic-release
       - name: Upload dist
-        if: steps.semantic.outputs.RELEASE == 'true'
+        if: steps.semantic.outputs.released == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: dist

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -57,7 +57,8 @@
             "release": "patch"
           }
         ]
-      }
+      },
+      "@semantic-release/release-notes-generator"
     ]
   ]
 }


### PR DESCRIPTION
dist was not uploaded because of typo in the release variable

release notes have not been updated because of the missing plugin