### PR TITLE
fix: shows last selected feature after page reload

### DIFF
--- a/apps/official/index.ts
+++ b/apps/official/index.ts
@@ -3,7 +3,6 @@ import {
   CustomSearchOptions,
   DefaultSearchOptions,
   LayerType,
-  SearchResultList,
 } from "../../src/app-config.types";
 import { AnimatedLogo } from "./components/AnimatedLogo";
 import buildJSON from "./build.json";
@@ -163,6 +162,7 @@ export const config: AppConfig = {
         "CI-to-plz": {
           datasourceId: "contact-index",
           geoId: "plz-details",
+          featurePropKey: "cca_2",
           geoProperty: "cca_2",
           dataProperty: "IdDistrict",
           transformData: transformData,
@@ -185,7 +185,6 @@ export const config: AppConfig = {
           id: "areas-fill",
           source: "CI-to-plz",
           clickable: true,
-          // showLegend: true,
           fn: (dataField, timeKey) => ({
             type: LayerType.FILL,
             paint: {

--- a/apps/official/index.ts
+++ b/apps/official/index.ts
@@ -1,9 +1,4 @@
-import {
-  AppConfig,
-  CustomSearchOptions,
-  DefaultSearchOptions,
-  LayerType,
-} from "../../src/app-config.types";
+import { AppConfig, CustomSearchOptions, DefaultSearchOptions, LayerType } from "../../src/app-config.types";
 import { AnimatedLogo } from "./components/AnimatedLogo";
 import buildJSON from "./build.json";
 import { Faq } from "./components/pages/Faq";

--- a/src/app-config.types.ts
+++ b/src/app-config.types.ts
@@ -126,6 +126,11 @@ export type FeatureInfoProps = {
 
 export type AppVisualMapping = {
   geoId: string;
+  /**
+   * The property key which identifies feature
+   * (To select a previously selected feature on reload)
+   */
+  featurePropKey: string;
   datasourceId: string;
   geoProperty: string;
   dataProperty: string;

--- a/src/components/CovMap.tsx
+++ b/src/components/CovMap.tsx
@@ -240,7 +240,7 @@ export const CovMap = () => {
             ),
           );
 
-          if(lngLat) {
+          if (lngLat) {
             dispatch(flyTo(lngLat[0], lngLat[1]));
           }
         });

--- a/src/components/CovMap.tsx
+++ b/src/components/CovMap.tsx
@@ -76,7 +76,7 @@ async function loadFlyTo() {
   FlyToInterpolator = FlyTo;
 }
 
-let jumpedToLastFeatureOnce = false
+let jumpedToLastFeatureOnce = false;
 
 export const CovMap = () => {
   const classes = useStyles();
@@ -232,26 +232,32 @@ export const CovMap = () => {
     if (jumpedToLastFeatureOnce) {
       return;
     }
-    
+
     if (mapRef.current && currentVisual && mappedSets[currentVisual] && currentFeaturePropId) {
       const mapset = mappedSets[currentVisual][currentFeaturePropId.mappingId];
       if (mapset) {
         const featurePropKey = config.visuals[currentVisual].mappings[currentFeaturePropId.mappingId].featurePropKey;
-        const feature = (mapset.geo as FeatureCollection).features
-          .find(({ properties }) => (properties || {})[featurePropKey] === currentFeaturePropId.featurePropId);
+        const feature = (mapset.geo as FeatureCollection).features.find(
+          ({ properties }) => (properties || {})[featurePropKey] === currentFeaturePropId.featurePropId,
+        );
         const map = mapRef.current.getMap();
-        
-        map.once('idle', (evt) => {
-          dispatch(AppApi.setCurrentFeature({ 
-            ...feature,
-            id: currentFeaturePropId.featureId,
-            source: currentFeaturePropId.mappingId,
-          }, currentFeaturePropId.lngLat));
+
+        map.once("idle", (evt) => {
+          dispatch(
+            AppApi.setCurrentFeature(
+              {
+                ...feature,
+                id: currentFeaturePropId.featureId,
+                source: currentFeaturePropId.mappingId,
+              },
+              currentFeaturePropId.lngLat,
+            ),
+          );
         });
         jumpedToLastFeatureOnce = true;
       }
     }
-  }, [currentVisual, mappedSets, mapRef])
+  }, [currentVisual, mappedSets, mapRef]);
 
   const handleMapLoaded = () => {
     setMapLoaded(true);

--- a/src/components/CovMap.tsx
+++ b/src/components/CovMap.tsx
@@ -7,6 +7,7 @@ import Typography from "@material-ui/core/Typography";
 import moment from "moment";
 import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { FeatureCollection } from "geojson";
 
 import { State } from "../state";
 import { AppApi } from "../state/app";
@@ -22,7 +23,6 @@ import { GLMap } from "./GLMap";
 import { Legend } from "./Legend";
 import { Settings } from "./Settings";
 import { config } from "app-config/index";
-import { switchViewToPlace } from "src/state/thunks/handleSearchQuery";
 import FixedSearch from "./FixedSearch";
 import { welcomeStepsConfig } from "./WelcomeStepsModal/welcomeStepsConfig";
 import { FeatureInfo } from "./FeatureInfo";
@@ -76,6 +76,8 @@ async function loadFlyTo() {
   FlyToInterpolator = FlyTo;
 }
 
+let jumpedToLastFeatureOnce = false
+
 export const CovMap = () => {
   const classes = useStyles();
   const dispatch = useThunkDispatch();
@@ -85,6 +87,8 @@ export const CovMap = () => {
   const currentVisual = useSelector((state: State) => state.app.currentVisual);
   const datasetFound = useSelector((state: State) => state.app.datasetFound);
   const currentFeature = useSelector((state: State) => state.app.currentFeature);
+  const currentFeaturePropId = useSelector((state: State) => state.app.currentFeaturePropId);
+  const mappedSets = useSelector((state: State) => state.app.mappedSets);
   const currentMappable = useSelector((state: State) => state.app.currentMappable);
   const currentDate = useSelector((state: State) => state.app.currentDate);
   const userPostalCode = useSelector((state: State) => state.app.userPostalCode);
@@ -182,7 +186,7 @@ export const CovMap = () => {
     const { features } = pointerEvent;
     if (features.length > 0) {
       /* handle multiple features. this happens when a street or text is clicked */
-      let countyFeatures;
+      let glFeature;
       if (features.length > 1) {
         // find out target features from index.ts
         const layers = config.visuals.covmap.layers;
@@ -191,21 +195,21 @@ export const CovMap = () => {
         const clickableLayer = layers.filter((layer) => layer.clickable); // get all clickable layers
         if (!clickableLayer.length) return;
 
-        countyFeatures = features.filter((feature) =>
+        glFeature = features.filter((feature) =>
           clickableLayer.some((layer) => feature.layer && feature.layer.id === layer.id),
         );
-        if (!countyFeatures.length) return;
+        if (!glFeature.length) return;
       } else {
-        countyFeatures = features;
+        glFeature = features;
       }
 
       if (mapRef.current) {
-        if (!mappingLayers.includes(countyFeatures[0].source)) {
+        if (!mappingLayers.includes(glFeature[0].source)) {
           return;
         }
       }
 
-      dispatch(AppApi.setCurrentFeature(countyFeatures[0], pointerEvent.lngLat));
+      dispatch(AppApi.setCurrentFeature(glFeature[0], pointerEvent.lngLat));
 
       if (stateViewport.zoom > 7) {
         const newViewport = {
@@ -220,17 +224,37 @@ export const CovMap = () => {
     }
   };
 
-  const flyToHome = () => {
-    // check for "valid" postal codes
-    if (!userPostalCode || isNaN(userPostalCode)) return;
-    dispatch(switchViewToPlace(String(userPostalCode)));
-  };
+  /**
+   * Takes the stored last select feature and sets it to current feature,
+   * to show the feature info last viewed after a reload.
+   */
+  useEffect(() => {
+    if (jumpedToLastFeatureOnce) {
+      return;
+    }
+    
+    if (mapRef.current && currentVisual && mappedSets[currentVisual] && currentFeaturePropId) {
+      const mapset = mappedSets[currentVisual][currentFeaturePropId.mappingId];
+      if (mapset) {
+        const featurePropKey = config.visuals[currentVisual].mappings[currentFeaturePropId.mappingId].featurePropKey;
+        const feature = (mapset.geo as FeatureCollection).features
+          .find(({ properties }) => (properties || {})[featurePropKey] === currentFeaturePropId.featurePropId);
+        const map = mapRef.current.getMap();
+        
+        map.once('idle', (evt) => {
+          dispatch(AppApi.setCurrentFeature({ 
+            ...feature,
+            id: currentFeaturePropId.featureId,
+            source: currentFeaturePropId.mappingId,
+          }, currentFeaturePropId.lngLat));
+        });
+        jumpedToLastFeatureOnce = true;
+      }
+    }
+  }, [currentVisual, mappedSets, mapRef])
 
   const handleMapLoaded = () => {
     setMapLoaded(true);
-    /* after map is completely loaded fly to useres home location after a short delay
-    tbh on most pcs this delay might as well be 0 */
-    setTimeout(flyToHome, 400);
   };
 
   return (

--- a/src/state/app.ts
+++ b/src/state/app.ts
@@ -163,9 +163,6 @@ class AppReducer extends Reducer<AppState> {
   public setCurrentDate(date: Date) {
     this.state.currentDate = date;
   }
-  public setCurrentFeaturePropId(date: Date) {
-    this.state.currentDate = date;
-  }
   public setCurrentMappable(mappable: Mappable) {
     this.state.currentMappable = mappable;
   }

--- a/src/state/app.ts
+++ b/src/state/app.ts
@@ -52,6 +52,13 @@ export type SnackbarMessage = {
   duration?: number;
 };
 
+export type FeaturePropId = {
+  mappingId: string;
+  featureId: string;
+  featurePropId: string;
+  lngLat?: Array<number>;
+};
+
 export type MapSetHolder = Record<VisualId, Record<string, MapSet>>;
 
 export interface AppState {
@@ -73,6 +80,7 @@ export interface AppState {
   searchResult: boolean;
   snackbarMessage: SnackbarMessage;
   currentFeature: CurrentFeature;
+  currentFeaturePropId: FeaturePropId | null;
   isInstalled: boolean;
   installPrompt: Function | null;
   currentLayerGroup: LayerGroup;
@@ -107,6 +115,7 @@ export const defaultAppState: AppState = {
     done: true,
   },
   currentFeature: { feature: null },
+  currentFeaturePropId: null,
   isInstalled: false,
   installPrompt: null,
   currentLayerGroup: defaultLayerGroup,
@@ -154,6 +163,9 @@ class AppReducer extends Reducer<AppState> {
   public setCurrentDate(date: Date) {
     this.state.currentDate = date;
   }
+  public setCurrentFeaturePropId(date: Date) {
+    this.state.currentDate = date;
+  }
   public setCurrentMappable(mappable: Mappable) {
     this.state.currentMappable = mappable;
   }
@@ -194,6 +206,13 @@ class AppReducer extends Reducer<AppState> {
       feature,
       lngLat,
       previousFeature: this.state.currentFeature?.feature,
+    };
+    const featurePropKey = config.visuals[this.state.currentVisual].mappings[feature.source].featurePropKey;
+    this.state.currentFeaturePropId = {
+      mappingId: feature.source,
+      featureId: feature.id,
+      featurePropId: feature.properties[featurePropKey],
+      lngLat,
     };
   }
   public setIsInstalled(installed: boolean) {

--- a/src/state/thunks/flyTo.ts
+++ b/src/state/thunks/flyTo.ts
@@ -1,0 +1,33 @@
+import { ReduxDispatch } from "../../useThunkDispatch";
+import { AppApi } from "../app";
+
+let FlyToInterpolator = null;
+async function loadFlyTo() {
+  if (FlyToInterpolator !== null) {
+    return
+  }
+  const { default: FlyTo } = await import(
+    /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
+  );
+  FlyToInterpolator = FlyTo;
+};
+
+
+export function flyTo(lng: number, lat: number) {
+  loadFlyTo();
+  return async (dispatch: ReduxDispatch, getState) => {
+    const { default: FlyToInterpolator } = await import(
+      /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
+    );
+    const state = getState().app;
+
+    const newViewport = {
+      ...state.viewport,
+      latitude: lat,
+      longitude: lng,
+      transitionDuration: 400,
+      transitionInterpolator: FlyToInterpolator ? new (FlyToInterpolator as any)({ curve: 1 }) : null,
+    };
+    dispatch(AppApi.setViewport(newViewport));
+  };
+}

--- a/src/state/thunks/flyTo.ts
+++ b/src/state/thunks/flyTo.ts
@@ -15,9 +15,6 @@ async function loadFlyTo() {
 export function flyTo(lng: number, lat: number) {
   loadFlyTo();
   return async (dispatch: ReduxDispatch, getState) => {
-    const { default: FlyToInterpolator } = await import(
-      /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
-    );
     const state = getState().app;
 
     const newViewport = {

--- a/src/state/thunks/flyTo.ts
+++ b/src/state/thunks/flyTo.ts
@@ -1,20 +1,11 @@
 import { ReduxDispatch } from "../../useThunkDispatch";
 import { AppApi } from "../app";
 
-let FlyToInterpolator = null;
-async function loadFlyTo() {
-  if (FlyToInterpolator !== null) {
-    return;
-  }
-  const { default: FlyTo } = await import(
-    /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
-  );
-  FlyToInterpolator = FlyTo;
-}
-
 export function flyTo(lng: number, lat: number) {
-  loadFlyTo();
   return async (dispatch: ReduxDispatch, getState) => {
+    const { default: FlyToInterpolator } = await import(
+      /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
+    );
     const state = getState().app;
 
     const newViewport = {

--- a/src/state/thunks/flyTo.ts
+++ b/src/state/thunks/flyTo.ts
@@ -4,14 +4,13 @@ import { AppApi } from "../app";
 let FlyToInterpolator = null;
 async function loadFlyTo() {
   if (FlyToInterpolator !== null) {
-    return
+    return;
   }
   const { default: FlyTo } = await import(
     /* webpackChunkName: "mapgl" */ "react-map-gl/dist/es6/utils/transition/viewport-fly-to-interpolator"
   );
   FlyToInterpolator = FlyTo;
-};
-
+}
 
 export function flyTo(lng: number, lat: number) {
   loadFlyTo();


### PR DESCRIPTION
Instead of always flying to "home" (aka given city code aka PLZ) after a reload or when re-opening the app, this now stores the selected feature and selects it again after a reload.