### PR TITLE
fix: calculate height of images before they are loaded in intro screens

### DIFF
--- a/src/components/WelcomeStepsModal/FullWidthFixedAspectImage.tsx
+++ b/src/components/WelcomeStepsModal/FullWidthFixedAspectImage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export const FullWidthFixedAspectImage: React.FC<{ aspect: number; src: string; alt: string }> = (props) => {
+  // the aspect value should be calculated as 100 * h / w
+  return (
+    <div style={{ position: "relative", width: "100%", height: "auto", padding: `${props.aspect}% 0 0 0` }}>
+      <img
+        src={props.src}
+        alt={props.alt}
+        style={{ position: "absolute", width: "100%", height: "100%", top: 0, left: 0 }}
+      />
+    </div>
+  );
+};

--- a/src/components/WelcomeStepsModal/WelcomeModal1.tsx
+++ b/src/components/WelcomeStepsModal/WelcomeModal1.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useCommonWelcomeModalStyles } from "./useCommonWelcomeModalStyles";
+import { FullWidthFixedAspectImage } from "./FullWidthFixedAspectImage";
 
 const useStyles = makeStyles(() => ({
   listItemDiv: {
@@ -29,7 +30,7 @@ export const WelcomeModal1: React.FC = () => {
     <>
       <Typography className={classes.title}>Willkommen bei der CovMap</Typography>
 
-      <img src={"/images/WelcomeModalImage1.svg"} alt="Welcome" width="100%" />
+      <FullWidthFixedAspectImage aspect={62.1} src="/images/WelcomeModalImage1.svg" alt="Welcome" />
 
       <div className={classes.infoTextDiv}>
         <div className={classes.listItemDiv}>

--- a/src/components/WelcomeStepsModal/WelcomeModal2.tsx
+++ b/src/components/WelcomeStepsModal/WelcomeModal2.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Typography } from "@material-ui/core";
 import { useCommonWelcomeModalStyles } from "./useCommonWelcomeModalStyles";
+import { FullWidthFixedAspectImage } from "./FullWidthFixedAspectImage";
 
 export const WelcomeModal2: React.FC = () => {
   const classes = useCommonWelcomeModalStyles();
@@ -9,8 +10,8 @@ export const WelcomeModal2: React.FC = () => {
     <>
       <Typography className={classes.title}>Was ist die CovMap?</Typography>
 
-      <img src={"/images/WelcomeModalImage2.svg"} alt="Welcome" width="100%" />
-      <img src={"/images/WelcomeModalImage2_sub.svg"} alt="Welcome" />
+      <FullWidthFixedAspectImage aspect={62.1} src="/images/WelcomeModalImage2.svg" alt="Welcome" />
+      <img src={"/images/WelcomeModalImage2_sub.svg"} alt="Welcome" width="124px" height="36px" />
 
       <div className={classes.infoTextDiv}>
         <Typography className={classes.largeText}>

--- a/src/components/WelcomeStepsModal/WelcomeModal3.tsx
+++ b/src/components/WelcomeStepsModal/WelcomeModal3.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Typography } from "@material-ui/core";
 import { useCommonWelcomeModalStyles } from "./useCommonWelcomeModalStyles";
+import { FullWidthFixedAspectImage } from "./FullWidthFixedAspectImage";
 
 export const WelcomeModal3: React.FC = () => {
   const classes = useCommonWelcomeModalStyles();
@@ -9,8 +10,8 @@ export const WelcomeModal3: React.FC = () => {
     <>
       <Typography className={classes.title}>Was zeigt mir die CovMap an?</Typography>
 
-      <img src={"/images/WelcomeModalImage3.svg"} alt="Welcome" width="100%" />
-      <img src={"/images/WelcomeModalImage3_sub.svg"} alt="Welcome" />
+      <FullWidthFixedAspectImage aspect={62.1} src="/images/WelcomeModalImage3.svg" alt="Welcome" />
+      <img src={"/images/WelcomeModalImage3_sub.svg"} alt="Welcome" width="113px" height="46px" />
 
       <div className={classes.infoTextDiv}>
         <Typography className={classes.largeText}>


### PR DESCRIPTION
- with this change the position of the text on the intro screens should be fixed and does not jump once the image is loaded