### PR TITLE
fix: make title of sub-pages (faq, imprint, ...) clickable on mobile

### DIFF
--- a/src/components/FixedSearch.tsx
+++ b/src/components/FixedSearch.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme) => ({
     height: "64px",
     display: "inline-flex",
     alignItems: "center",
+    pointerEvents: "auto",
     [theme.breakpoints.down("xs")]: {
       left: "0px",
       right: "48px", // right on the edge of the hamburger menu button

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
       // on mobile devices
       backgroundColor: "transparent",
       boxShadow: "none",
+      pointerEvents: "none",
     },
   },
   title: {
@@ -183,7 +184,7 @@ export const NavBar = () => {
   return (
     <AppBar classes={{ root: classes.appBar }} style={{ height: 64, flex: "0 0 auto" }}>
       <Toolbar className={classes.fullHeightToolbar}>
-        <Link to="/">
+        <Link to="/" style={{ pointerEvents: "auto" }}>
           {!isMobile && ((Logo && <Logo />) || <img src={config.buildJSON.logoSrc} className={classes.logo} />)}
         </Link>
         {showSearch && <FixedSearch />}


### PR DESCRIPTION
The app bar was not click-through on mobile. Just transparent.