### PR TITLE
fix: set error dialog to map component

### DIFF
--- a/src/components/CovMap.tsx
+++ b/src/components/CovMap.tsx
@@ -269,7 +269,7 @@ export const CovMap = () => {
   };
 
   return (
-    <div className={classes.main}>
+    <div id="mapParentDiv" className={classes.main}>
       <div className={classes.currentInfo}>
         {/*<Typography variant="h2" color="primary">{visual.name}</Typography>*/}
         <Typography variant="h2" color="primary">
@@ -298,7 +298,10 @@ export const CovMap = () => {
         style={{
           zIndex: 1190,
           touchAction: "none",
+          position: "absolute",
         }}
+        container={() => document.getElementById("mapParentDiv")}
+        BackdropProps={{ style: { position: "absolute" } }}
       >
         <DialogTitle
           id="simple-dialog-title"

--- a/src/components/FixedSearch.tsx
+++ b/src/components/FixedSearch.tsx
@@ -1,5 +1,7 @@
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import React from "react";
+import { useSelector } from "react-redux";
+import { State } from "src/state";
 import { Search } from "./Search";
 
 const useStyles = makeStyles((theme) => ({
@@ -20,12 +22,9 @@ const useStyles = makeStyles((theme) => ({
 
 const FixedSearch = () => {
   const classes = useStyles();
+  const datasetFound = useSelector((state: State) => state.app.datasetFound);
 
-  return (
-    <div className={classes.searchContainer}>
-      <Search />
-    </div>
-  );
+  return <div className={classes.searchContainer}>{datasetFound === false ? null : <Search />}</div>;
 };
 
 export default FixedSearch;


### PR DESCRIPTION
- sets the error dialog to the map component so the navigation is still functional
- removes the search if there is no data in order to not run into an error in the search (or confuse the user)


![screencapture-936e6e0b-4300-4eb6-950c-cc41c3ab0c10-8080-apps-codespaces-githubusercontent-2020-10-31-10_01_30](https://user-images.githubusercontent.com/13590797/97775337-151d8a80-1b60-11eb-8bb9-0f2a628432df.png)